### PR TITLE
eat(api/user/terms): Refactor and test user terms API endpoint

### DIFF
--- a/src/app/api/user/terms/__tests__/route.test.ts
+++ b/src/app/api/user/terms/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+import { POST } from "../route";
+import { MongoClient } from "mongodb";
+
+// --- MOCKING DEPENDENCIES ---
+jest.mock("@/lib/auth0", () => ({
+  auth0: {
+    getSession: jest.fn(),
+  },
+}));
+import { auth0 } from "@/lib/auth0";
+const mockGetSession = auth0.getSession as jest.Mock;
+
+// 2. Mock the mongodb module and its methods dynamically
+jest.mock("mongodb");
+const mockUpdateOne = jest.fn();
+const mockFindOne = jest.fn();
+const mockClose = jest.fn();
+const mockCollection = {
+  updateOne: mockUpdateOne,
+  findOne: mockFindOne,
+};
+const mockDb = {
+  collection: () => mockCollection,
+};
+const mockClient = {
+  connect: jest.fn().mockResolvedValue({
+    db: () => mockDb,
+    close: mockClose,
+  }),
+  db: () => mockDb,
+  close: mockClose,
+};
+(MongoClient as unknown as jest.Mock).mockImplementation(() => mockClient);
+
+// --- TEST SUITE SETUP ---
+const originalEnv = process.env;
+const MOCK_USER_SUB = "auth0|12345";
+const MOCK_REQUEST_BODY = {
+  accepted: true,
+  cookiePreferences: { essential: true, analytics: false },
+};
+
+describe("POST /api/user/terms", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      MONGODB_URI: "mongodb://localhost:27017/test",
+      MONGO_CLIENT: "test",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return 401 if no user session exists", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toBe("Unauthorized");
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("should return 401 if session exists but user.sub is missing", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: {} });
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.message).toBe("Unauthorized");
+    expect(mockUpdateOne).not.toHaveBeenCalled();
+  });
+
+  it("should return 404 if user is not found in the database", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { sub: MOCK_USER_SUB } });
+    mockUpdateOne.mockResolvedValueOnce({ modifiedCount: 0 });
+    mockFindOne.mockResolvedValueOnce(null);
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.message).toBe("User not found");
+    expect(mockUpdateOne).toHaveBeenCalled();
+    expect(mockFindOne).toHaveBeenCalledWith({ sub: MOCK_USER_SUB });
+  });
+
+  it("should return 409 if user has already accepted terms", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { sub: MOCK_USER_SUB } });
+    mockUpdateOne.mockResolvedValueOnce({ modifiedCount: 0 });
+    mockFindOne.mockResolvedValueOnce({
+      sub: MOCK_USER_SUB,
+      terms_acceptance: true,
+    });
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.message).toBe("User already accepted terms");
+    expect(mockUpdateOne).toHaveBeenCalled();
+    expect(mockFindOne).toHaveBeenCalledWith({ sub: MOCK_USER_SUB });
+  });
+
+  it("should return 200 with the updated user document on success", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { sub: MOCK_USER_SUB } });
+    mockUpdateOne.mockResolvedValueOnce({ modifiedCount: 1 });
+    const mockUpdatedUser = {
+      sub: MOCK_USER_SUB,
+      terms_acceptance: true,
+      cookie_preferences: { essential: true, analytics: false },
+    };
+    mockFindOne.mockResolvedValueOnce(mockUpdatedUser);
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+
+    const response = await POST(mockRequest);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(mockUpdatedUser);
+    expect(mockUpdateOne).toHaveBeenCalledWith(
+      { sub: MOCK_USER_SUB },
+      expect.objectContaining({
+        $set: {
+          terms_acceptance: true,
+          terms_acceptance_date: expect.any(Date), // <-- Add this
+          cookie_preferences: { essential: true, analytics: false },
+          cookie_preferences_date: expect.any(Date), // <-- Add this
+        },
+      }),
+    );
+    expect(mockFindOne).toHaveBeenCalledWith({ sub: MOCK_USER_SUB });
+  });
+
+  it("should return 500 if an unexpected error occurs during database operation", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockGetSession.mockResolvedValueOnce({ user: { sub: MOCK_USER_SUB } });
+    // Mock the connection to fail to trigger the catch block
+    mockClient.connect.mockRejectedValueOnce(
+      new Error("Database connection failed"),
+    );
+    const mockRequest = {
+      json: () => Promise.resolve(MOCK_REQUEST_BODY),
+    } as Request;
+    const response = await POST(mockRequest);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.message).toBe("Internal server error");
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Error in /user/terms POST:",
+      expect.any(Error),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/app/api/user/terms/route.ts
+++ b/src/app/api/user/terms/route.ts
@@ -2,14 +2,6 @@ import { auth0 } from "@/lib/auth0";
 import { NextResponse } from "next/server";
 import { MongoClient } from "mongodb";
 
-if (!process.env.MONGODB_URI) {
-  throw new Error("MONGODB_URI is not defined");
-}
-
-const client = new MongoClient(process.env.MONGODB_URI);
-const clientPromise = client.connect();
-const collectionName = process.env.MONGO_CLIENT ?? "";
-
 export async function POST(request: Request) {
   try {
     const session = await auth0.getSession();
@@ -20,7 +12,12 @@ export async function POST(request: Request) {
     const body = await request.json();
     const { accepted, cookiePreferences } = body;
 
-    const clientConnection = await clientPromise;
+    if (!process.env.MONGODB_URI) {
+      throw new Error("Server configuration error: MONGODB_URI is not defined");
+    }
+    const client = new MongoClient(process.env.MONGODB_URI);
+    const clientConnection = await client.connect();
+    const collectionName = process.env.MONGO_CLIENT ?? "";
     const db = clientConnection.db(collectionName);
     const collection = db.collection("user");
 
@@ -39,13 +36,22 @@ export async function POST(request: Request) {
     );
 
     if (updateResult.modifiedCount === 0) {
+      const userExists = await collection.findOne({ sub });
+      if (!userExists) {
+        return NextResponse.json(
+          { message: "User not found" },
+          { status: 404 },
+        );
+      }
       return NextResponse.json(
-        { message: "User not found or already accepted terms" },
-        { status: 404 },
+        { message: "User already accepted terms" },
+        { status: 409 },
       );
     }
 
     const updatedUser = await collection.findOne({ sub });
+
+    await clientConnection.close();
 
     return NextResponse.json(updatedUser, { status: 200 });
   } catch (error) {


### PR DESCRIPTION
This pull request refactors the POST endpoint at /api/user/terms to fix a testing issue caused by variable hoisting. Previously, the MongoClient instance was created at the module level, which meant the Jest mocks were not applied in time for the tests. By moving the database connection logic inside the POST function, the mock client is now correctly used, and all tests for the endpoint pass.

Additionally, this change improves the endpoint's error handling. It now explicitly differentiates between a user who does not exist (404 Not Found) and a user who has already accepted the terms (409 Conflict), providing a more accurate status code and message. I have also updated the corresponding test to correctly assert that the updateOne call includes dynamic Date objects using expect.any(Date).

Checklist
[x] My code follows the project's coding standards.

[x] I have included a clear, concise description of the changes.

[ ] I have linked the relevant issue(s) to this PR.

[x] My changes are ready to be reviewed.