### PR TITLE
fix: change encryption key encoding from utf-8 to base64

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+APP_BASE_URL=your-app_base_url
+AUTH0_CLIENT_ID=your-auth0_client_id
+AUTH0_CLIENT_SECRET=your-auth0_client_secret
+AUTH0_DOMAIN=your-auth0_domain
+AUTH0_SECRET=your-auth0_secret
+ENCRYPTION_IV=your-encryption_iv
+ENCRYPTION_KEY=your-encryption_key
+GEMINI_API_KEY=your-gemini_api_key
+MONGODB_URI=your-mongodb_uri
+MONGO_CLIENT=your-mongo_client

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ yarn-error.log*
 *.log.*
 
 # Environmental variables
-.env*
+.env
 .env.local
 
 # IDE and OS files

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -17,7 +17,7 @@ const collectionName = process.env.MONGO_CLIENT ?? "";
 // Encryption function
 function encrypt(text: string) {
   const iv = Buffer.from(IV, "utf-8");
-  const secretKey = Buffer.from(SECRET_KEY, "utf-8");
+  const secretKey = Buffer.from(SECRET_KEY, "base64");
 
   const cipher = crypto.createCipheriv(ALGORITHM, secretKey, iv);
 
@@ -36,7 +36,7 @@ function encrypt(text: string) {
 
 function decrypt(encryptedData: string, authTag: string) {
   const iv = Buffer.from(IV, "utf-8"); // Same IV used during encryption
-  const secretKey = Buffer.from(SECRET_KEY, "utf-8");
+  const secretKey = Buffer.from(SECRET_KEY, "base64");
 
   const decipher = crypto.createDecipheriv(ALGORITHM, secretKey, iv);
 


### PR DESCRIPTION
## Changes
- Update Buffer.from encoding in encrypt/decrypt functions
- Ensures proper 32-byte key length for encryption algorithm
- Added .env.example file (+ changed gitignore rules)

## Error fixed
- Fixes ERR_CRYPTO_INVALID_KEYLEN error for AES-256-GCM

while following the README config 
❌ Error in /getUser: RangeError: Invalid key length
    at encrypt (src\app\api\user\route.ts:22:25)
    at GET (src\app\api\user\route.ts:86:30)
  20 |   const secretKey = Buffer.from(SECRET_KEY, "utf-8");
  21 |
> 22 |   const cipher = crypto.createCipheriv(ALGORITHM, secretKey, iv);
     |                         ^
  23 |
  24 |   // Encrypt the text
  25 |   let encrypted = cipher.update(text, "utf8", "hex"); {
  code: 'ERR_CRYPTO_INVALID_KEYLEN'
}
 GET /api/user 500 in 613ms